### PR TITLE
Fix linking of zshrc

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,4 +3,4 @@ sudo chsh "$(id -un)" --shell "/usr/bin/zsh"
 sudo apt-get update
 sudo apt-get -y install screen
 
-ln -s /workspaces/.codespaces/.persistedshare/dotfiles/.zshrc ~/.zshrc
+ln -sf /workspaces/.codespaces/.persistedshare/dotfiles/.zshrc ~/.zshrc


### PR DESCRIPTION
Because the file already exists we can create a new symbolic link. So we have to force it.